### PR TITLE
TOOLS-2343 Adjust release process for new multi-branch Jenkins jobs

### DIFF
--- a/tools/releng/launch-build
+++ b/tools/releng/launch-build
@@ -29,7 +29,7 @@ function usage() {
 	if [[ -n $1 ]]; then
 		printf "%s: %s\n" "$PROGNAME" "$1" >&2
 	fi
-	printf "usage:\n    $PROGNAME [-v] [-H url] [-b BRANCH] [-F PLAT_FLAVOR] [-u auth] <-g gitrepo> project\n" >&2
+	printf "usage:\n    $PROGNAME [-v] [-H url] [-b BRANCH] [-F PLAT_FLAVOR] [-u auth] <-g GITREPO> project\n" >&2
 	exit 2
 }
 
@@ -83,7 +83,7 @@ if [[ -z $JENKINS_AUTH ]]; then
 fi
 
 if [[ -z $GITREPO ]]; then
-	usage "-v gitrepo must be specified"
+	usage "-g GITREPO must be specified"
 fi
 
 if [[ -n $BRANCH ]]; then

--- a/tools/releng/launch-build
+++ b/tools/releng/launch-build
@@ -29,15 +29,16 @@ function usage() {
 	if [[ -n $1 ]]; then
 		printf "%s: %s\n" "$PROGNAME" "$1" >&2
 	fi
-	printf "usage:\n    $PROGNAME [-v] [-H url] [-b BRANCH] [-F PLAT_FLAVOR] [-u auth] project\n" >&2
+	printf "usage:\n    $PROGNAME [-v] [-H url] [-b BRANCH] [-F PLAT_FLAVOR] [-u auth] <-g gitrepo> project\n" >&2
 	exit 2
 }
 
-while getopts 'F:H:u:b:hv' opt; do
+while getopts 'F:H:u:b:hvg:' opt; do
 	case $opt in
 	H) JENKINS_URL=$OPTARG;;
 	u) JENKINS_AUTH=$OPTARG;;
 	b) BRANCH=$OPTARG;;
+	g) GITREPO=$OPTARG;;
 	v) VERBOSE=true;;
 	F) PLAT_FLAVOR=$OPTARG;;
 	h) usage;;
@@ -81,6 +82,10 @@ if [[ -z $JENKINS_AUTH ]]; then
 	usage "JENKINS_AUTH must be set to <user>:<api token> (get it here: ${JENKINS_URL}/me/configure)"
 fi
 
+if [[ -z $GITREPO ]]; then
+	usage "-v gitrepo must be specified"
+fi
+
 if [[ -n $BRANCH ]]; then
 	printf "Building %s with BRANCH=%s\n" "$PROJECT" "$BRANCH"
 	BUILD_PARAM=`printf '{"name":"BRANCH", "value": "%s"}' $BRANCH`
@@ -113,7 +118,7 @@ case $PROJECT in
 			BUILD_PARAM="${BUILD_PARAM},$(printf '{"name": "PLATFORM_BUILD_FLAVOR", "value": "%s"}' "${PLAT_FLAVOR}")"
 		fi
 		;;
-	"headnode"|"headnode-debug"|"headnode-joyent")
+	"headnode"|"headnode-debug")
 		if [[ -n "$BRANCH" ]]; then
 			BUILD_PARAM="${BUILD_PARAM},$(printf '{"name": "CONFIGURE_BRANCHES", "value": "bits-branch: %s"}' "${BRANCH}")"
 		fi
@@ -127,7 +132,16 @@ else
 fi
 
 CRUMB_URL="$JENKINS_URL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,\":\",//crumb)"
-BUILD_URL="$JENKINS_URL/job/$PROJECT/build"
+
+case $PROJECT in
+	"platform"|"headnode"|"headnode-debug")
+		BUILD_URL="$JENKINS_URL/job/$PROJECT/build"
+		;;
+	*)
+		BUILD_URL="$JENKINS_URL/job/joyent-org/job/$GITREPO/job/$BRANCH/build"
+		;;
+esac
+set -x
 
 # Fetch the CSRF token to send in our request's headers
 CRUMB=`curl ${CURL_OPTS[@]} --user "$JENKINS_AUTH" "$CRUMB_URL"`

--- a/tools/releng/ls-missing-release-builds
+++ b/tools/releng/ls-missing-release-builds
@@ -86,15 +86,18 @@ fi
 
 filtered_targets="$*"
 if [[ -z "$targets" ]]; then
+    # we get the mg label since that's part of the component manta path
+    # we get the buildisprivate label to find non-public builds
+    # we get name since that's a component of the jenkins job to launch
     targets=$(jr list -H -l mg,release \
-        -o labels.mg,labels.buildisprivate,htmlUrl | grep -v ^sdcsso)
+        -o labels.mg,labels.buildisprivate,name | grep -v ^sdcsso)
 fi
 
 # Ensure mls is setup properly at all.
 mls /Joyent_Dev/public/builds >/dev/null \
     || fatal "cannot list /Joyent_Dev/public/builds"
 
-echo "$targets" | while read target buildisprivate htmlurl; do
+echo "$targets" | while read target buildisprivate gitrepo; do
 
     # if we've been asked to only look for specific targets, then
     # we should skip to the next item if this target isn't in our list
@@ -116,14 +119,11 @@ echo "$targets" | while read target buildisprivate htmlurl; do
         latest_mpath=/Joyent_Dev/public/builds/$target/$release-latest
     fi
 
-    gitrepo=$(echo $htmlurl | awk -F/ '{print $NF}')
-
     case $target in
         "platform")
             # For the platform build, only the 'smartos-live' repository
             # is relevant, ignore the others.
-            smartos_live=$(echo $gitrepo | grep smartos-live || true)
-            if [[ -z "$smartos_live" ]]; then
+            if [[ "$gitrepo" != "smartos_live" ]]; then
                 continue
             fi
             PLAT_FLAVOR_ARG="-F $PLATFORM_BUILD_FLAVOR"

--- a/tools/releng/ls-missing-release-builds
+++ b/tools/releng/ls-missing-release-builds
@@ -51,7 +51,7 @@ function usage() {
 }
 
 # Specify the type of platform build to do.
-PLATFORM_BUILD_FLAVOR='smartos-and-triton'
+PLATFORM_BUILD_FLAVOR='triton-and-smartos'
 
 #---- mainline
 
@@ -84,25 +84,48 @@ if [[ -z "$JR_MANIFESTS" ]]; then
     JR_MANIFESTS=/Volumes/projects/triton.git/tools/jr-manifest.json,/Volumes/projects/manta.git/tools/jr-manifest.json,/Volumes/projects/smartos-live.git/tools/jr-manifest.json"
 fi
 
-targets="$*"
+filtered_targets="$*"
 if [[ -z "$targets" ]]; then
-    targets=$(jr list -H -l mg,release -o labels | json -ag mg buildisprivate | sort -u \
-        | grep -v '^sdcsso')
+    targets=$(jr list -H -l mg,release \
+        -o labels.mg,labels.buildisprivate,htmlUrl | grep -v ^sdcsso)
 fi
 
 # Ensure mls is setup properly at all.
 mls /Joyent_Dev/public/builds >/dev/null \
     || fatal "cannot list /Joyent_Dev/public/builds"
 
-echo "$targets" | while read target buildisprivate; do
+echo "$targets" | while read target buildisprivate htmlurl; do
+
+    # if we've been asked to only look for specific targets, then
+    # we should skip to the next item if this target isn't in our list
+    if [[ -n "$filtered_targets" ]]; then
+        process_target=""
+        for filter in $filtered_targets; do
+            if [[ "$target" == "$filter" ]]; then
+                process_target=true
+            fi
+        done
+        if [[ -z "$process_target" ]]; then
+            continue
+        fi
+    fi
+
     if [[ "$buildisprivate" == "true" ]]; then
         latest_mpath=/Joyent_Dev/stor/builds/$target/$release-latest
     else
         latest_mpath=/Joyent_Dev/public/builds/$target/$release-latest
     fi
 
+    gitrepo=$(echo $htmlurl | awk -F/ '{print $NF}')
+
     case $target in
-        "platform"|"platform-debug")
+        "platform")
+            # For the platform build, only the 'smartos-live' repository
+            # is relevant, ignore the others.
+            smartos_live=$(echo $gitrepo | grep smartos-live || true)
+            if [[ -z "$smartos_live" ]]; then
+                continue
+            fi
             PLAT_FLAVOR_ARG="-F $PLATFORM_BUILD_FLAVOR"
             ;;
         *)
@@ -113,6 +136,6 @@ echo "$targets" | while read target buildisprivate; do
     latest=$(mls $latest_mpath 2>/dev/null || true)
     if [[ -z "$latest" ]]; then
         echo "# $target, '$latest_mpath' does not exist" >&2
-        echo "./tools/releng/launch-build ${PLAT_FLAVOR_ARG} -b $release $target"
+        echo "./tools/releng/launch-build ${PLAT_FLAVOR_ARG} -b $release -g $gitrepo $target"
     fi
 done


### PR DESCRIPTION
This is part of the work to switch our release engineering processes over to the "new-Jenkins" style jobs.

For now, it omits the platform and headnode builds and uses the old free-style jobs for those as we haven't finished converting them to new-style jobs. It does depend on us completing all of MANTA-4675 before the release builds will start, otherwise, I'll need more exceptions to the 'launch-build' script.

I haven't updated the documentation for the release process yet - specifically, I haven't mentioned that the release builds should all start automatically, which depends on how we get on with TOOLS-2362. Worst case, we get duplicate builds as a result of people following: https://modocs.joyent.us/engdoc/master/sdcrelease/index.html#step-5-run-jenkins-builds

I wonder should we have ls-missing-builds check for the presence of a release build-in-progress before starting one (or require a --force flag if we have one release build for this release already)