### PR TITLE
TOOLS-2392 node-contract should not be an ignored jr-manifest.json entry

### DIFF
--- a/tools/jr-manifest.json
+++ b/tools/jr-manifest.json
@@ -203,6 +203,9 @@
             "name": "node-cmdutil"
         },
         {
+            "name": "node-contract"
+        },
+        {
             "name": "node-crc"
         },
         {
@@ -1218,7 +1221,6 @@
         "node-checker",
         "node-codel",
         "node-consulite",
-        "node-contract",
         "node-debug-school",
         "node-debugging-methodologies",
         "node-dns",

--- a/tools/jr-manifest.json
+++ b/tools/jr-manifest.json
@@ -203,9 +203,6 @@
             "name": "node-cmdutil"
         },
         {
-            "name": "node-contract"
-        },
-        {
             "name": "node-crc"
         },
         {


### PR DESCRIPTION
As mentioned in the bug report, if there's a way to look for other repositories that might have the same issue, I'd be happy to update the PR with those repos.

I did do a hound search for "illumos_" but only node-contract matches:

https://hound.joyent.us/?q=require%5C(%27illumos_&i=nope&files=&repos=