### PR TITLE
TRITON-1961 add Jenkinsfile to sdc-headnode

### DIFF
--- a/tools/releng/launch-build
+++ b/tools/releng/launch-build
@@ -95,9 +95,10 @@ case $PROJECT in
 			BUILD_PARAM="$(printf '{"name": "PLATFORM_BUILD_FLAVOR", "value": "%s"}' "${PLAT_FLAVOR}")"
 		fi
 		;;
-	"headnode"|"headnode-debug")
+	"headnode")
 		if [[ -n "$BRANCH" ]]; then
 			BUILD_PARAM="$(printf '{"name": "CONFIGURE_BRANCHES", "value": "bits-branch: %s"}' "${BRANCH}")"
+			BUILD_PARAM="${BUILD_PARAM},{\"name\": \"INCLUDE_DEBUG_STAGE\", \"value\": \"true\"}"
 		fi
 		;;
 esac

--- a/tools/releng/launch-build
+++ b/tools/releng/launch-build
@@ -87,18 +87,7 @@ if [[ -z $GITREPO ]]; then
 	usage "-g GITREPO must be specified"
 fi
 
-case $PROJECT in
-	"headnode"|"headnode-debug")
-		if [[ -n $BRANCH ]]; then
-			printf "Set BUILD_PARAM for %s: BRANCH=%s\n" "$PROJECT" "$BRANCH"
-			BUILD_PARAM=$(printf '{"name":"BRANCH", "value": "%s"}' $BRANCH)
-		fi
-		BUILD_URL="$JENKINS_URL/job/$PROJECT/build"
-		;;
-	*)
-		BUILD_URL="$JENKINS_URL/job/joyent-org/job/$GITREPO/job/$BRANCH/build"
-		;;
-esac
+BUILD_URL="$JENKINS_URL/job/joyent-org/job/$GITREPO/job/$BRANCH/build"
 
 case $PROJECT in
 	"platform")
@@ -108,7 +97,7 @@ case $PROJECT in
 		;;
 	"headnode"|"headnode-debug")
 		if [[ -n "$BRANCH" ]]; then
-			BUILD_PARAM="${BUILD_PARAM},$(printf '{"name": "CONFIGURE_BRANCHES", "value": "bits-branch: %s"}' "${BRANCH}")"
+			BUILD_PARAM="$(printf '{"name": "CONFIGURE_BRANCHES", "value": "bits-branch: %s"}' "${BRANCH}")"
 		fi
 		;;
 esac


### PR DESCRIPTION
This mostly just removes code from launch-build to deal with the last remaining freestyle job.

https://jenkins.joyent.us/job/joyent-org/job/sdc-headnode/job/PR-33/4/parameters/ shows the parameters it's passing now (in this case, "-b PR-33" corresponds to the sdc-headnode pull request that contains this Jenkinsfile. Normally, release builds would use "-b release-2020xxyy")