### PR TITLE
OS-8153 Jenkinsfile should include a way to build only the strap cache tarball

### DIFF
--- a/tools/releng/launch-build
+++ b/tools/releng/launch-build
@@ -93,6 +93,7 @@ case $PROJECT in
 	"platform")
 		if [[ -n "$PLAT_FLAVOR" ]]; then
 			BUILD_PARAM="$(printf '{"name": "PLATFORM_BUILD_FLAVOR", "value": "%s"}' "${PLAT_FLAVOR}")"
+			BUILD_PARAM="${BUILD_PARAM},{\"name\": \"ONLY_BUILD_STRAP_CACHE\", \"value\": \"false\"}"
 		fi
 		;;
 	"headnode")


### PR DESCRIPTION
Since the jenkins api doesn't set default parameters when called from external scripts, we need to set that. Otherwise we don't build any stages when triggering the smartos-live build from here.